### PR TITLE
Add ability to log completed verifications into a Discord channel

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -25,7 +25,8 @@ class AuthController < ApplicationController
 
       auth_request.player.complete_osu_verification(params[:state], osu_user)
 
-      render json: { message: 'Verification successful' }, status: :ok
+      render json: { message: 'Verification successful. Contact the Discord server administrators if you still do not have access.' },
+             status: :ok
     rescue OsuAuthErrors::TimeoutError => e
       render json: { message: e.message }, status: :bad_request
     rescue OsuAuthErrors::OsuAuthError => e

--- a/db/migrate/20210919102754_add_verification_log_channel_to_discord_server.rb
+++ b/db/migrate/20210919102754_add_verification_log_channel_to_discord_server.rb
@@ -1,0 +1,9 @@
+class AddVerificationLogChannelToDiscordServer < ActiveRecord::Migration[6.0]
+  def up
+    add_column :discord_servers, :verification_log_channel_id, :bigint
+  end
+
+  def down
+    remove_column :discord_servers, :verification_log_channel_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_18_112413) do
+ActiveRecord::Schema.define(version: 2021_09_19_102754) do
 
   create_table "beatmaps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2021_09_18_112413) do
     t.bigint "verified_role_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "verification_log_channel_id"
     t.index ["discord_id"], name: "index_discord_servers_on_discord_id", unique: true
   end
 

--- a/lib/discord/commands/command_base.rb
+++ b/lib/discord/commands/command_base.rb
@@ -7,15 +7,20 @@ class CommandBase
 
     @options = {}
 
-    OptionParser.new do |opts|
-      required_options.each do |opt|
-        opts.on(*opt)
-      end
+    begin
+      OptionParser.new do |opts|
+        required_options.each do |opt|
+          opts.on(*opt)
+        end
 
-      opts.on('-h', '--help', 'Prints this help message') do
-        @help_message = opts
-      end
-    end.parse!(event.message.content.split(' '), into: @options)
+        opts.on('-h', '--help', 'Prints this help message') do
+          @help_message = opts
+        end
+      end.parse!(event.message.content.split(' '), into: @options)
+    rescue OptionParser::MissingArgument
+      @event.respond("Missing arguments")
+      raise
+    end
   end
 
   def response

--- a/lib/discord/commands/registration/set_verification_log_channel.rb
+++ b/lib/discord/commands/registration/set_verification_log_channel.rb
@@ -1,0 +1,36 @@
+require 'discordrb'
+
+require_relative '../command_base'
+
+class SetVerificationLogChannel < CommandBase
+  protected
+
+  def required_options
+    [
+      ['-c TEXT', '--channel', 'The ID of the channel to use for registering new users.']
+    ]
+  end
+
+  def requires_admin
+    true
+  end
+
+  def make_response
+    Rails.logger.tagged(self.class.name) do
+      Rails.logger.debug("New set channel request #{@event.message.author.defined_permission?(:administrator)}")
+    end
+
+    return @event.respond('Channel ID is required!') if @options[:channel].nil?
+
+    return @event.respond('Channel does not exist or bot does not have access') unless @event.message.server.text_channels.any? do |c|
+      c.id.to_s == @options[:channel]
+    end
+
+    server = DiscordServer.create_or_find_by(discord_id: @event.message.server.id)
+
+    server.verification_log_channel_id = @options[:channel]
+    server.save!
+
+    @event.respond('Updated log channel!')
+  end
+end

--- a/lib/discord/modules/registration_commands.rb
+++ b/lib/discord/modules/registration_commands.rb
@@ -1,6 +1,7 @@
 require 'discordrb'
 
 require_relative '../commands/registration/set_channel'
+require_relative '../commands/registration/set_verification_log_channel'
 require_relative '../commands/registration/set_verified_role'
 require_relative '../commands/registration/register'
 
@@ -9,6 +10,10 @@ module RegistrationCommands
 
   command(:set_register_channel, aliases: [], description: 'Set channel for registration') do |event, *args|
     SetChannel.new(event, *args).response
+  end
+
+  command(:set_verification_log_channel, aliases: [], description: 'Set channel for logging successful verifications') do |event, *args|
+    SetVerificationLogChannel.new(event, *args).response
   end
 
   command(:set_verified_role, aliases: [], description: 'Set the role to be applied to verified users') do |event, *args|


### PR DESCRIPTION
Adds a new command:
- `set_verification_log_channel`: Admin only. Logs successfully completed osu! account verifications to this channel if configured.