### PR TITLE
Add a command to retrieve osu! profile of mentioned user

### DIFF
--- a/lib/discord/commands/command_base.rb
+++ b/lib/discord/commands/command_base.rb
@@ -28,7 +28,10 @@ class CommandBase
 
     return 'Can only be invoked by adminstrators!' if requires_admin && !invoker_admin?
 
-    make_response
+    begin
+      make_response
+    rescue Discordrb::Errors::NoPermission
+    end
   end
 
   protected

--- a/lib/discord/commands/registration/whois.rb
+++ b/lib/discord/commands/registration/whois.rb
@@ -1,0 +1,31 @@
+require_relative '../command_base'
+
+class Whois < CommandBase
+  protected
+
+  def make_response
+    if @event.message.mentions.length != 1
+      return @event.respond('Whois requires one mentioned user')
+    end
+
+    target = @event.message.mentions.first
+    player = Player.find_by(discord_id: target.id)
+
+    return @event.respond("User #{target.name} not found") if player.nil?
+
+    @event.message.channel.send_embed do |embed|
+      embed.title = player.name
+      embed.url = "https://osu.ppy.sh/users/#{player.osu_id}"
+      embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: "https://a.ppy.sh/#{player.osu_id}")
+      embed.color = EMBED_GREEN
+      embed.fields = [
+        Discordrb::Webhooks::EmbedField.new(name: 'Discord user', value: "<@#{player.discord_id}>", inline: true),
+        Discordrb::Webhooks::EmbedField.new(name: 'osu! ID', value: player.osu_id, inline: true),
+        Discordrb::Webhooks::EmbedField.new(
+          name: 'Verified on',
+          value: player.osu_auth_request&.updated_at.change(offset: "+05:30").to_formatted_s(:long) || 'Never'
+        )
+      ]
+    end
+  end
+end

--- a/lib/discord/modules/registration_commands.rb
+++ b/lib/discord/modules/registration_commands.rb
@@ -5,6 +5,7 @@ require_relative '../commands/registration/set_verification_log_channel'
 require_relative '../commands/registration/set_verified_role'
 require_relative '../commands/registration/register'
 require_relative '../commands/registration/unregister'
+require_relative '../commands/registration/whois'
 
 module RegistrationCommands
   extend Discordrb::Commands::CommandContainer
@@ -27,5 +28,9 @@ module RegistrationCommands
 
   command(:unregister, aliases: [], description: 'Unlinks Discord user from osu! user. Admin only.') do |event, *args|
     Unregister.new(event, *args).response
+  end
+
+  command(:whois, aliases: [:who], description: 'Display linked osu! profile') do |event, *args|
+    Whois.new(event, *args).response
   end
 end


### PR DESCRIPTION
Adds a new command:
- `whois, who`: Displays the osu! profile linked to a mentioned user if it exists
