### PR TITLE
Add ability to ban Discord users by osu! ID

### DIFF
--- a/app/models/ban_history.rb
+++ b/app/models/ban_history.rb
@@ -1,0 +1,6 @@
+class BanHistory < ApplicationRecord
+  belongs_to :player
+  belongs_to :banned_by, foreign_key: 'banned_by_id', class_name: 'Player'
+
+  enum ban_types: { none: 0, soft: 1, hard: 2 }, _prefix: :ban_type
+end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -15,6 +15,8 @@ class Player < ApplicationRecord
   has_and_belongs_to_many :match_teams
   has_many :hosted_tournaments, foreign_key: 'id', class_name: 'Tournament'
 
+  enum ban_statuses: { none: 0, soft: 1, hard: 2 }, _prefix: :ban_status
+
   def email_required?
     # new_record? ? false : super
     false

--- a/db/migrate/20211124050519_add_banned_status_to_player.rb
+++ b/db/migrate/20211124050519_add_banned_status_to_player.rb
@@ -1,0 +1,18 @@
+class AddBannedStatusToPlayer < ActiveRecord::Migration[6.0]
+  def up
+    add_column :players, :ban_status, :integer, null: false, default: 0
+
+    create_table :ban_histories do |t|
+      t.references :player, foreign_key: { to_table: :players, on_update: :cascade, on_delete: :cascade }, null: false
+      t.references :banned_by, foreign_key: { to_table: :players, on_update: :cascade, on_delete: :nullify }, null: true
+      t.integer :ban_type, default: 0, null: false
+      t.string :reason, null: true
+      t.timestamps
+    end
+  end
+
+  def down
+    remove_column :players, :ban_status
+    drop_table :ban_histories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_22_063551) do
+ActiveRecord::Schema.define(version: 2021_11_24_050519) do
+
+  create_table "ban_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "player_id", null: false
+    t.bigint "banned_by_id"
+    t.integer "ban_type", default: 0, null: false
+    t.string "reason"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["banned_by_id"], name: "index_ban_histories_on_banned_by_id"
+    t.index ["player_id"], name: "index_ban_histories_on_player_id"
+  end
 
   create_table "beatmaps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
@@ -130,6 +141,7 @@ ActiveRecord::Schema.define(version: 2021_09_22_063551) do
     t.datetime "discord_last_spoke"
     t.boolean "osu_verified", default: false
     t.datetime "osu_verified_on"
+    t.integer "ban_status", default: 0, null: false
     t.index ["confirmation_token"], name: "index_players_on_confirmation_token", unique: true
     t.index ["discord_id"], name: "index_unique_discord_ids", unique: true
     t.index ["email"], name: "index_players_on_email", unique: true
@@ -152,6 +164,8 @@ ActiveRecord::Schema.define(version: 2021_09_22_063551) do
     t.index ["host_player_id"], name: "fk_rails_978fcfdc7f"
   end
 
+  add_foreign_key "ban_histories", "players", column: "banned_by_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "ban_histories", "players", on_update: :cascade, on_delete: :cascade
   add_foreign_key "match_teams", "matches"
   add_foreign_key "match_teams", "players", column: "captain_id"
   add_foreign_key "matches", "match_teams", column: "winner_id"

--- a/lib/discord/commands/command_base.rb
+++ b/lib/discord/commands/command_base.rb
@@ -4,6 +4,14 @@ class CommandBase
   def initialize(event, *args)
     @event = event
     @bot_args = args
+    @server = {
+      db_server: DiscordServer.find_by_discord_id(event.message.server.id),
+      discordrb_server: event.message.server,
+    }
+    @invoker = {
+      db_player: Player.find_by_discord_id(event.message.author.id),
+      discordrb_user: event.message.author,
+    }
 
     @options = {}
 

--- a/lib/discord/commands/registration/ban.rb
+++ b/lib/discord/commands/registration/ban.rb
@@ -1,0 +1,45 @@
+require 'discordrb'
+
+require_relative '../command_base'
+
+class Ban < CommandBase
+  protected
+
+  def required_options
+    [
+      ['-t TEXT', '--type', 'Ban type. One of [soft, hard]. Default is hard ban.'],
+      ['-r TEXT', '--reason', 'Reason for ban.']
+    ]
+  end
+
+  def requires_admin
+    true
+  end
+
+  def make_response
+    mentioned_member = @server[:discordrb_server].member(@event.message.mentions.first&.id)
+
+    return @event.respond("Unable to find user #{mentioned_member.name} in the server") if mentioned_member.nil?
+    return @event.respond("#{mentioned_member.name} is already banned") unless BannedUser.find_by_discord_id(mentioned_member.id).nil?
+
+    ban_type = @options[:type]&.to_sym || BannedUser.ban_types[:hard]
+    target_db_player = Player.find_by_discord_id(mentioned_member.id)
+    reason = @options[:reason] || "Banned by #{@event.message.author.name} (#{@event.message.author.id})"
+
+    ActiveRecord::Base.transaction do
+      BannedUser.create(
+        discord_id: mentioned_member.id,
+        ban_type: ban_type,
+        osu_player: target_db_player,
+        created_by: @invoker[:db_player],
+        reason: reason
+      )
+
+      if ban_type == BannedUser.ban_types[:soft] && @server[:db_server].verified_role_id && mentioned_member.role?(server.verified_role_id)
+        mentioned_member.remove_role(@server[:db_server].verified_role_id)
+      elsif ban_type == BannedUser.ban_types[:hard]
+        @server[:discordrb_server].ban(mentioned_member, 0, reason)
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registration/register.rb
+++ b/lib/discord/commands/registration/register.rb
@@ -11,9 +11,17 @@ class Register < CommandBase
 
     return if server.registration_channel_id.nil? || server.registration_channel_id != @event.message.channel.id
 
-    if player.osu_verified
+    if player.osu_verified && player.ban_status == Player.ban_statuses[:none]
       @event.message.author.add_role(server.verified_role_id)
       @event.respond("Verification completed #{mention_invoker}!")
+
+      return
+    end
+
+    if player.ban_status == Player.ban_statuses[:soft]
+      @event.message.author.pm(
+        "You are soft banned on #{@server[:discordrb_server].name}, which means you cannot get the \"member\" role but you may access roles from #self-assign-roles"
+      )
 
       return
     end
@@ -31,7 +39,7 @@ class Register < CommandBase
         "#{mention_invoker} KelaBot doesn't have permission to DM you. Please check that server members have permission to send you DMs in your privacy settings."
       )
     rescue StandardError => e
-      Rails.logger.tagged(self.class.name) { Rails.logger.error("Failed to execute register command\n#{e.backtrace}")}
+      Rails.logger.tagged(self.class.name) { Rails.logger.error("Failed to execute register command\n#{e.backtrace}") }
 
       @event.respond(
         "#{mention_invoker} something went wrong, contact the administrators to complete your verification."

--- a/lib/discord/commands/registration/unban.rb
+++ b/lib/discord/commands/registration/unban.rb
@@ -1,0 +1,54 @@
+require 'discordrb'
+
+require_relative '../command_base'
+
+class Unban < CommandBase
+  protected
+
+  def required_options
+    [
+      ['-d INTEGER', '--discord-id', 'Discord ID linked to the user'],
+      ['-o INTEGER', '--osu-id', 'osu! ID to unban']
+    ]
+  end
+
+  def requires_admin
+    true
+  end
+
+  def make_response
+    return @event.respond('No user specified to unregister') if @event.message.mentions.length.zero?
+
+    return @event.respond('Mention a single user to unregister') if @event.message.mentions.length > 1
+
+    mentioned_member = @event.message.server.member(@event.message.mentions.first.id)
+
+    player = nil
+
+    if mentioned_member
+      player = Player.find_by(discord_id: mentioned_member.id)
+    elsif @options[:osu_id]
+      player = Player.find_by(osu_id: @options[:osu_id])
+    elsif @options[:discord_id]
+      player = Player.find_by(discord_id: @options[:discord_id])
+    end
+
+    return @event.respond("User not found") if player.nil?
+    return @event.respond("User #{player.name} is not banned") if player.ban_status == Player.ban_statuses[:none]
+
+    ActiveRecord::Base.transaction do
+      BanHistory.create(
+        player: player,
+        banned_by: @invoker[:db_player],
+        reason: "Unbanned by #{@invoker[:discordrb_user].name} (#{@invoker[:discordrb_user].id})",
+        ban_type: BanHistory.ban_types[:none]
+      )
+
+      player.ban_status = Player.ban_statuses[:none]
+
+      player.save!
+
+      @event.respond("Unbanned #{mentioned_member.name}")
+    end
+  end
+end

--- a/lib/discord/modules/registration_commands.rb
+++ b/lib/discord/modules/registration_commands.rb
@@ -6,6 +6,7 @@ require_relative '../commands/registration/set_verified_role'
 require_relative '../commands/registration/register'
 require_relative '../commands/registration/unregister'
 require_relative '../commands/registration/whois'
+require_relative '../commands/registration/ban'
 
 module RegistrationCommands
   extend Discordrb::Commands::CommandContainer

--- a/lib/discord/modules/registration_commands.rb
+++ b/lib/discord/modules/registration_commands.rb
@@ -7,6 +7,7 @@ require_relative '../commands/registration/register'
 require_relative '../commands/registration/unregister'
 require_relative '../commands/registration/whois'
 require_relative '../commands/registration/ban'
+require_relative '../commands/registration/unban'
 
 module RegistrationCommands
   extend Discordrb::Commands::CommandContainer
@@ -38,5 +39,9 @@ module RegistrationCommands
 
   command(:ban, aliases: [], description: 'Ban a user') do |event, *args|
     Ban.new(event, *args).response
+  end
+
+  command(:unban, aliases: [], description: 'Unban a user') do |event, *args|
+    Unban.new(event, *args).response
   end
 end

--- a/lib/discord/modules/registration_commands.rb
+++ b/lib/discord/modules/registration_commands.rb
@@ -14,7 +14,8 @@ module RegistrationCommands
     SetChannel.new(event, *args).response
   end
 
-  command(:set_verification_log_channel, aliases: [], description: 'Set channel for logging successful verifications') do |event, *args|
+  command(:set_verification_log_channel, aliases: [],
+                                         description: 'Set channel for logging successful verifications') do |event, *args|
     SetVerificationLogChannel.new(event, *args).response
   end
 
@@ -32,5 +33,9 @@ module RegistrationCommands
 
   command(:whois, aliases: [:who], description: 'Display linked osu! profile') do |event, *args|
     Whois.new(event, *args).response
+  end
+
+  command(:ban, aliases: [], description: 'Ban a user') do |event, *args|
+    Ban.new(event, *args).response
   end
 end


### PR DESCRIPTION
Adds two new commands:
- `ban`: Accepts a `-t` switch with values being one of `[hard, soft]`. Soft bans remove the verified role configured for the server and prevent re-registration whereas hard bans ban the user on Discord and immediately ban any other Discord accounts that attempt to verify the same osu! account
- `unban`: Removes any bans with one of mentioned user, osu! ID, Discord ID in that order and allows for that user to re-register 
    - `unban @user`
    - `unban -o <osu_id>`
    - `unban -d <discord_id>`

Only applicable to members who have registered their osu! accounts with the bot.