### PR TITLE
Change things to make production assets work again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY ./Gemfile ./
 COPY ./Gemfile.lock ./
 
 RUN bundle install
+RUN yarn install
 
 RUN groupadd ots && useradd -g ots ots
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
 //= link_tree ../builds

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  config.eager_load = false
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false
@@ -29,6 +29,7 @@ Rails.application.configure do
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
+  config.assets.debug = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w( application.js application.css )

--- a/docker/development/boot.sh
+++ b/docker/development/boot.sh
@@ -22,6 +22,7 @@ fi
 
 _serve() {
   ruby --version
+  bundle --version
   ./bin/rails s -b 0.0.0.0
   # ./bin/dev
 }
@@ -30,7 +31,6 @@ _wds() {
   node --version
   yarn --version
   echo "Booting webpack dev server..."
-  yarn install
   yarn run webpack serve
 }
 

--- a/package.json
+++ b/package.json
@@ -42,9 +42,7 @@
     "react_ujs": "^2.6.2",
     "sass-loader": "^13.0.2",
     "uuid": "^8.3.2",
-    "voca": "^1.4.0"
-  },
-  "devDependencies": {
+    "voca": "^1.4.0",
     "@babel/core": "^7.18.13",
     "@babel/plugin-transform-runtime": "^7.18.10",
     "@babel/preset-env": "^7.18.10",
@@ -78,5 +76,6 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.10.1",
     "webpack-remove-empty-scripts": "^0.8.3"
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
- Move all `devDependencies` to `dependencies` because rails production is stupid
- Explicitly add `application.css` and `application.js` to precompile
- Move yarn install from startup script to Docker image build
- Remove unnecessary stylesheet link in `manifest.js`