### PR TITLE
Fix duplicate player creation

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -14,7 +14,10 @@ class AuthController < Devise::OmniauthCallbacksController
       auth = request.env["omniauth.auth"]
       params = Rack::Utils.parse_query(Base64.decode64(request.params["state"]))
       raw_user = auth["extra"]["raw_info"]
-      player = Player.from_omniauth(auth)
+      player = Player.from_omniauth(
+        auth,
+        state: params["s"]
+      )
 
       flow_code =
         if !params["f"].empty? && params["f"] == "bot" && !params["s"].empty?

--- a/db/migrate/20240522021920_add_unique_uid_provider.rb
+++ b/db/migrate/20240522021920_add_unique_uid_provider.rb
@@ -1,0 +1,11 @@
+class AddUniqueUidProvider < ActiveRecord::Migration[7.0]
+  def change
+    add_index :player_auths, %i[uid provider], unique: true, name: 'unique_external_account'
+
+    remove_foreign_key :player_auths, column: :player_id
+    add_foreign_key :player_auths, :players, column: :player_id, on_delete: :cascade
+
+    remove_foreign_key :discord_exps, column: :player_id
+    add_foreign_key :discord_exps, :players, column: :player_id, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_17_074941) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_22_021920) do
   create_table "auth_providers", primary_key: "name", id: :string, charset: "utf8mb3", force: :cascade do |t|
     t.string "display_name"
     t.boolean "enabled"
@@ -127,6 +127,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_17_074941) do
     t.index ["player_id"], name: "index_player_auths_on_player_id"
     t.index ["provider", "player_id", "uid"], name: "index_player_auths_on_provider_and_player_id_and_uid", unique: true
     t.index ["provider"], name: "index_player_auths_on_provider"
+    t.index ["uid", "provider"], name: "unique_external_account", unique: true
   end
 
   create_table "players", charset: "utf8mb3", force: :cascade do |t|
@@ -185,12 +186,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_17_074941) do
   add_foreign_key "ban_histories", "players", column: "banned_by_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "ban_histories", "players", on_update: :cascade, on_delete: :cascade
   add_foreign_key "discord_exps", "discord_servers"
-  add_foreign_key "discord_exps", "players"
+  add_foreign_key "discord_exps", "players", on_delete: :cascade
   add_foreign_key "match_teams", "matches"
   add_foreign_key "match_teams", "players", column: "captain_id"
   add_foreign_key "matches", "match_teams", column: "winner_id"
   add_foreign_key "matches", "tournaments", on_update: :cascade, on_delete: :cascade
   add_foreign_key "player_auths", "auth_providers", column: "provider", primary_key: "name"
-  add_foreign_key "player_auths", "players"
+  add_foreign_key "player_auths", "players", on_delete: :cascade
   add_foreign_key "tournaments", "players", column: "host_player_id", on_update: :cascade, on_delete: :nullify
 end

--- a/lib/discord/bot.rb
+++ b/lib/discord/bot.rb
@@ -238,7 +238,9 @@ module Discord
           )
       end
 
-      player.discord_exp.find_or_create_by(discord_server: server)
+      player.discord_exp.find_or_create_by(discord_server: server) do |exp|
+        exp.detailed_exp = DiscordHelper::INITIAL_EXP
+      end
     end
   end
 end

--- a/lib/discord/bot.rb
+++ b/lib/discord/bot.rb
@@ -77,19 +77,19 @@ module Discord
             stats
               .except(:player)
               .map do |k, v|
-                {
-                  name: "**#{k.to_s.humanize}**",
-                  inline: true,
-                  value:
-                    if k == :best_accuracy
-                      v[:accuracy]
-                    elsif v.is_a?(Array)
-                      v.length
-                    else
-                      v
-                    end.to_s
-                }
-              end
+              {
+                name: "**#{k.to_s.humanize}**",
+                inline: true,
+                value:
+                  if k == :best_accuracy
+                    v[:accuracy]
+                  elsif v.is_a?(Array)
+                    v.length
+                  else
+                    v
+                  end.to_s
+              }
+            end
         }
 
         event.respond("", false, embed)
@@ -157,13 +157,13 @@ module Discord
         @client
           .channel(server.verification_log_channel_id, guild)
           .send_embed do |embed|
-            embed.title = player.name
-            embed.url = "https://osu.ppy.sh/users/#{player.osu.uid}"
-            embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: "https://a.ppy.sh/#{player.osu.uid}")
-            embed.color = EMBED_GREEN
-            embed.description = "Verification completed"
-            embed.fields = [Discordrb::Webhooks::EmbedField.new(name: "Discord user", value: member.mention || "<User not in server>")]
-          end
+          embed.title = player.name
+          embed.url = "https://osu.ppy.sh/users/#{player.osu.uid}"
+          embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: "https://a.ppy.sh/#{player.osu.uid}")
+          embed.color = EMBED_GREEN
+          embed.description = "Verification completed"
+          embed.fields = [Discordrb::Webhooks::EmbedField.new(name: "Discord user", value: member.mention || "<User not in server>")]
+        end
       end
     end
 
@@ -234,7 +234,19 @@ module Discord
         player =
           Player.create(
             name: DiscordHelper.sanitise_username(event.user.username),
-            identities: PlayerAuth.create([{ provider: :discord, uid: event.user.id, raw: {}, uname: event.user.username }])
+            identities: PlayerAuth.create([{
+              provider: :discord,
+              uid: event.user.id,
+              raw: {
+                username: event.user.global_name || event.user.username,
+                id: event.user.id,
+                joined_at: event.user.joined_at,
+                bot_account: event.user.bot_account,
+                discriminator: event.user.discriminator,
+                avatar_id: event.user.avatar_id,
+                public_flags: event.user.public_flags
+              },
+              uname: DiscordHelper::sanitise_username(event.user.username) }])
           )
       end
 


### PR DESCRIPTION
Needs additional cleanup of old data before deployment.

```sql
create temporary table if not exists players_to_delete as (select players.id
                                                           from players
                                                                    join (select *
                                                                          from player_auths
                                                                          where provider = 'discord'
                                                                            and uid in (select uid from player_auths group by uid having count(uid) > 1)
                                                                          order by created_at desc) as c on players.id = c.player_id
                                                           where players.last_sign_in_at is null);

delete
from player_auths
where player_id in (select id from players_to_delete);

delete
from discord_exps
where player_id in (select id from players_to_delete);

delete
from players
where id in (select id from players_to_delete);
```