### PR TITLE
Handle missing Discord bot query state correctly for osu login

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -20,7 +20,7 @@ class AuthController < Devise::OmniauthCallbacksController
       )
 
       flow_code =
-        if !params["f"].empty? && params["f"] == "bot" && !params["s"].empty?
+        if !params['f'].nil? && !params["f"].empty? && params["f"] == "bot" && !params["s"].empty?
           AuthController::FLOW_CODE["discord_bot"]
         elsif !player&.persisted?
           AuthController::FLOW_CODE["direct"]
@@ -156,14 +156,10 @@ class AuthController < Devise::OmniauthCallbacksController
 
     return redirect_to root_path if exception.nil?
 
-    logger.debug(exception)
+    logger.error(exception)
+    logger.error(exception.backtrace.join('\n'))
     Sentry.capture_exception(exception)
 
     render template: "auth/failure"
-  end
-
-  private
-
-  def map_omniauth_state
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -320,10 +320,16 @@ Devise.setup do |config|
                   callback_path: "/authorise/osu",
                   state: ->(env) do
                     request = Rack::Request.new(env)
-                    query = Rack::Utils.parse_query(Base64.decode64(request.params["s"]))
+
                     # Generate the default state if the params for Discord-bot origin osu! linkage are not found, otherwise use the already generated state
                     # containing linkage information.
-                    if request.params["s"].empty? || query["f"].empty? || query["f"] != "bot" || query["s"].empty?
+                    if request.params["s"].nil? || request.params['s'].empty?
+                      return SecureRandom.hex(24)
+                    end
+
+                    query = Rack::Utils.parse_query(Base64.decode64(request.params["s"]))
+
+                    if query["f"].empty? || query["f"] != "bot" || query["s"].empty?
                       return SecureRandom.hex(24)
                     end
                     request.params["s"]


### PR DESCRIPTION
Fixes direct osu! login (and not Discord bot link) not working correctly