### PR TITLE
Fix prune API call

### DIFF
--- a/app/jobs/monthly_kela_job.rb
+++ b/app/jobs/monthly_kela_job.rb
@@ -1,11 +1,15 @@
 require_relative '../../lib/discord/bot'
 
 class MonthlyKelaJob < ApplicationJob
+  include SemanticLogger
+
   queue_as :default
 
-  def perform(*args)
+  def perform(reason)
+    logger.info("Starting monthly kela job")
+
     ::Discord::OsuDiscordBot.instance.initialize! do |bot|
-      bot.kela!
+      bot.kela!(reason)
     end
   end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -2,3 +2,4 @@ production:
   monthly_kela:
     class: MonthlyKelaJob
     schedule: "0 12 1 * *"
+    args: ["Monthly roulette"]

--- a/lib/discord/bot.rb
+++ b/lib/discord/bot.rb
@@ -64,7 +64,7 @@ module Discord
       logger.info "Osu Discord bot has stopped"
     end
 
-    def kela!
+    def kela(reason)!
       DiscordServer.all.each do |s|
         logger.debug("Checking for monthly prune", { server: s })
 
@@ -76,7 +76,7 @@ module Discord
           next
         end
 
-        logger.debug("Beginning monthly prune", { server: s })
+        logger.debug("Beginning prune", { server: s })
 
         @client
           .server(s.discord_id)
@@ -91,10 +91,10 @@ module Discord
           :guilds_sid_prune,
           s.discord_id,
           :post,
-          "#{Discordrb::API.api_base}/guilds/#{s.discord_id}/prune",
-          { days: 30, include_roles: [s.verified_role_id] },
+          "#{Discordrb::API.api_base}/guilds/#{s.discord_id}/prune?days=30&include_roles=#{s.verified_role_id}&compute_prune_count=false",
+          nil,
           Authorization: @client.token,
-          'X-Audit-Log-Reason': "Monthly roulette"
+          'X-Audit-Log-Reason': reason
         )
 
         logger.info("Monthly member prune completed", { server: s, pruned: response["pruned"] })

--- a/spec/jobs/monthly_kela_job_spec.rb
+++ b/spec/jobs/monthly_kela_job_spec.rb
@@ -14,6 +14,6 @@ describe "MonthlyKelaJob" do
     allow(Discord::OsuDiscordBot).to receive(:instance)
       .and_return(mock_bot)
 
-    MonthlyKelaJob.perform_now
+    MonthlyKelaJob.perform_now("Test")
   end
 end


### PR DESCRIPTION
For some reason Discord POST API expects query parameters instead of JSON body.